### PR TITLE
Add package flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,13 @@
         });
   in {
     formatter = eachSystem ({pkgs, ...}: pkgs.alejandra);
+    packages = eachSystem ({pkgs, ...}: {
+      default = pkgs.writeShellApplication {
+        name = "nix-develop-gha";
+        runtimeInputs = [pkgs.gnugrep pkgs.openssl.bin pkgs.coreutils];
+        text = builtins.readFile ./nix-develop-gha.sh;
+      };
+    });
     devShells = eachSystem ({pkgs, ...}: {
       default = pkgs.mkShell {
         packages = [pkgs.shellcheck pkgs.actionlint];


### PR DESCRIPTION
Hopefully addresses #8

cc @xgroleau @msanft. Do you have the bandwidth to test if this branch can help your use case?  The README changes should explain how to use it, you'd just have to change the flake references to `github:nicknovitski/nix-develop/flake-package`.