### PR TITLE
Get openssl from Nix if not available in path

### DIFF
--- a/nix-develop-gha.sh
+++ b/nix-develop-gha.sh
@@ -9,6 +9,9 @@ contains() {
 	grep "$1" --silent <<<"$2"
 }
 
+# Get openssl from Nix if it isn't available on the system
+OPENSSL=$(which openssl 2>/dev/null || echo "$(nix build nixpkgs#openssl.bin --no-link --print-out-paths)/bin/openssl")
+
 envOutput=
 
 # Iterate over the output of `env -0`
@@ -60,7 +63,7 @@ while IFS='=' read -r -d '' n v || exit "$n"; do
 	# Ref https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
 	# Use a random string as a heredoc delimiter for multi-line strings
 	if (("$(wc -l <<<"$v")" > 1)); then
-		delimiter=$(openssl rand -base64 18)
+		delimiter=$($OPENSSL rand -base64 18)
 		if contains "$delimiter" "$v"; then
 			echo "Environment variable $n contains randomly generated string $delimiter, file an issue and buy a lottery ticket."
 			exit 1


### PR DESCRIPTION
`nix-develop-gha.sh` depends on several bash builtins, `nix`, and `openssl`. If run on a self-hosted runner on NixOS `openssl` isn't available in PATH by default and the action fails. This change checks whether `openssl` is present in path and uses it, or otherwise gets it from `nix build` which we already depend on, without polluting PATH.

Test plan:
- Tested on a self-hosted runner with only `nix` available. Failed before, works after.
- Tested on a GitHub hosted runner. Worked before, works after.